### PR TITLE
chore: do not affect other processors when gallery processor failed

### DIFF
--- a/src/main/java/run/halo/lightgallery/LightGalleryHeadProcessor.java
+++ b/src/main/java/run/halo/lightgallery/LightGalleryHeadProcessor.java
@@ -35,7 +35,6 @@ import run.halo.app.theme.dialect.TemplateHeadProcessor;
 @RequiredArgsConstructor
 public class LightGalleryHeadProcessor implements TemplateHeadProcessor {
     private static final String TEMPLATE_ID_VARIABLE = "_templateId";
-    final PropertyPlaceholderHelper placeholderHelper = new PropertyPlaceholderHelper("${", "}");
     private final ReactiveSettingFetcher reactiveSettingFetcher;
     private final PathPatternRouteMatcher routeMatcher = new PathPatternRouteMatcher();
 
@@ -56,7 +55,10 @@ public class LightGalleryHeadProcessor implements TemplateHeadProcessor {
                     }
                     model.add(modelFactory.createText(lightGalleryScript(matchResult.domSelectors())));
                 })
-                .onErrorContinue((throwable, o) -> log.warn("LightGalleryHeadProcessor process failed", throwable))
+                .onErrorResume(e -> {
+                    log.error("LightGalleryHeadProcessor process failed", e);
+                    return Mono.empty();
+                })
                 .then();
     }
 


### PR DESCRIPTION
#### What this PR does?
LightGalleryHeadProcessor 执行失败时不要影响其他处理器的执行，因此使用 onErrorResume 来返回 empty

/kind improvement
#### Does this PR introduce a user-facing change?
```release-note
None
```