### PR TITLE
fix: lightgallery does not work when there are multiple DOM elements with the same class

### DIFF
--- a/src/main/java/run/halo/lightgallery/LightGalleryHeadProcessor.java
+++ b/src/main/java/run/halo/lightgallery/LightGalleryHeadProcessor.java
@@ -83,9 +83,16 @@ public class LightGalleryHeadProcessor implements TemplateHeadProcessor {
                           if (node) {
                             node.dataset.src = node.src;
                           }
-                        });
-                        lightGallery(document.querySelector("%s"), {
-                          selector: "img",
+                          
+                          const galleries = document.querySelectorAll(`%s`);
+                            
+                          if (galleries.length > 0) {
+                            galleries.forEach(function (node) {
+                              lightGallery(node, {
+                                  selector: "img",
+                              });
+                            });
+                          }
                         });
                         """.formatted(domSelector, domSelector)
                 )


### PR DESCRIPTION
修复匹配区域设置为 class 选择器时，无法打开图片的问题。

Fixes #10 

```release-note
修复匹配区域设置为 class 选择器时，无法打开图片的问题。
```